### PR TITLE
Migrate Spring Security To Spring 3.x

### DIFF
--- a/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/framework/security/SecurityConfig.java
+++ b/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/framework/security/SecurityConfig.java
@@ -1,24 +1,6 @@
 package org.lowcoder.api.framework.security;
 
 
-import static org.lowcoder.infra.constant.NewUrl.GITHUB_STAR;
-import static org.lowcoder.infra.constant.Url.APPLICATION_URL;
-import static org.lowcoder.infra.constant.Url.CONFIG_URL;
-import static org.lowcoder.infra.constant.Url.CUSTOM_AUTH;
-import static org.lowcoder.infra.constant.Url.DATASOURCE_URL;
-import static org.lowcoder.infra.constant.Url.GROUP_URL;
-import static org.lowcoder.infra.constant.Url.INVITATION_URL;
-import static org.lowcoder.infra.constant.Url.ORGANIZATION_URL;
-import static org.lowcoder.infra.constant.Url.QUERY_URL;
-import static org.lowcoder.infra.constant.Url.STATE_URL;
-import static org.lowcoder.infra.constant.Url.USER_URL;
-import static org.lowcoder.sdk.constants.Authentication.ANONYMOUS_USER;
-import static org.lowcoder.sdk.constants.Authentication.ANONYMOUS_USER_ID;
-
-import java.util.List;
-
-import javax.annotation.Nonnull;
-
 import org.lowcoder.api.framework.filter.UserSessionPersistenceFilter;
 import org.lowcoder.api.home.SessionUserService;
 import org.lowcoder.domain.user.model.User;
@@ -27,6 +9,7 @@ import org.lowcoder.sdk.config.CommonConfig;
 import org.lowcoder.sdk.util.CookieHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
@@ -41,6 +24,15 @@ import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import org.springframework.web.server.adapter.ForwardedHeaderTransformer;
 
+import javax.annotation.Nonnull;
+import java.util.List;
+
+import static org.lowcoder.infra.constant.NewUrl.GITHUB_STAR;
+import static org.lowcoder.infra.constant.Url.*;
+import static org.lowcoder.sdk.constants.Authentication.ANONYMOUS_USER;
+import static org.lowcoder.sdk.constants.Authentication.ANONYMOUS_USER_ID;
+
+@Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 public class SecurityConfig {


### PR DESCRIPTION
## Proposed changes
- Add @Configuration to the `SecurityConfig` class as Spring 3 has now removed the @Configuration from the `@EnableWebFluxSecurity` and `@EnableReactiveMethodSecurity` annotations. Consequently, the configuration was never being applied. 

UT:
![base-route](https://github.com/lowcoder-org/lowcoder/assets/133229382/9443806e-0a5d-4a73-b399-db78a0ddee50)
![user-api](https://github.com/lowcoder-org/lowcoder/assets/133229382/ca221dc3-3170-49a0-85b9-a8f3935a2deb)


## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
