### PR TITLE
fix externalUrl redis for helm chart

### DIFF
--- a/deploy/helm/templates/api-service/configMap.yaml
+++ b/deploy/helm/templates/api-service/configMap.yaml
@@ -15,7 +15,7 @@ data:
   {{- if .Values.redis.enabled }}
   REDIS_URL: "redis://{{ $name }}-redis-master.{{ $nameSpace }}.svc.cluster.local:6379"
   {{- else }}
-  REDIS_URL: {{- .Values.redis.externalUrl | quote }}
+  REDIS_URL: {{ .Values.redis.externalUrl | quote }}
   {{- end }}
   {{- if .Values.apiService.nodeServiceUrl }}
   LOWCODER_NODE_SERVICE_URL: {{ .Values.apiService.nodeServiceUrl | quote }}


### PR DESCRIPTION
the `-` is messing with the rendering and makes it so you can't render templates with externalUrl

this should fix it