### PR TITLE
Remove default log file appenders

### DIFF
--- a/server/api-service/lowcoder-sdk/src/main/resources/logback-spring.xml
+++ b/server/api-service/lowcoder-sdk/src/main/resources/logback-spring.xml
@@ -2,7 +2,6 @@
 <configuration>
     <contextName>lowcoder-logback</contextName>
     <property name="pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %level %class{50}#%M:%L %X{userId} %X{httpMethod} %X{path} [%thread]: %msg %n"/>
-    <property name="LOG_HOME" value="./logs"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -10,53 +9,8 @@
         </encoder>
     </appender>
 
-    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_HOME}/main.log</file>
-        <append>true</append>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/main.log.%d.%i</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>10GB</totalSizeCap>
-        </rollingPolicy>
-        <encoder>
-            <pattern>${pattern}</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ASYNC-FILE-INFO" class="ch.qos.logback.classic.AsyncAppender">
-        <discardingThreshold>0</discardingThreshold>
-        <queueSize>2000</queueSize>
-        <appender-ref ref="FILE-INFO"/>
-    </appender>
-
-    <appender name="QUERY-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_HOME}/query-error.log</file>
-        <append>true</append>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/query-error.log.%d.%i</fileNamePattern>
-            <maxFileSize>50MB</maxFileSize>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>10GB</totalSizeCap>
-        </rollingPolicy>
-        <encoder>
-            <pattern>${pattern}</pattern>
-        </encoder>
-    </appender>
-    <appender name="ASYNC-QUERY-ERROR" class="ch.qos.logback.classic.AsyncAppender">
-        <discardingThreshold>0</discardingThreshold>
-        <queueSize>2000</queueSize>
-        <appender-ref ref="QUERY-ERROR"/>
-    </appender>
-
-    <logger name="queryError" level="ERROR" additivity="false">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="QUERY-ERROR"/>
-    </logger>
-
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="ASYNC-FILE-INFO"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
## Proposed changes
Since lowcoder is mostly run in containers, logging to files by default is not a good behavior.
This change removes file logger appenders and keeps only console logging.
In all-in-one image logging is still kept in a log file due to the configuration of the service executed within the container.

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
n/a
