### PR TITLE
container add scroll Switch

### DIFF
--- a/client/packages/lowcoder/src/comps/comps/containerComp/containerComp.tsx
+++ b/client/packages/lowcoder/src/comps/comps/containerComp/containerComp.tsx
@@ -14,10 +14,12 @@ import { disabledPropertyView, hiddenPropertyView } from "comps/utils/propertyUt
 import { trans } from "i18n";
 import { BoolCodeControl } from "comps/controls/codeControl";
 import { DisabledContext } from "comps/generators/uiCompBuilder";
+import { BoolControl } from "@lowcoder-ee/comps/controls/boolControl";
 
 export const ContainerBaseComp = (function () {
   const childrenMap = {
     disabled: BoolCodeControl,
+    showScroll: BoolControl.DEFAULT_TRUE,
   };
   return new ContainerCompBuilder(childrenMap, (props, dispatch) => {
     return (
@@ -32,6 +34,8 @@ export const ContainerBaseComp = (function () {
           <Section name={sectionNames.interaction}>{disabledPropertyView(children)}</Section>
           <Section name={sectionNames.layout}>
             {children.container.getPropertyView()}
+            {!children.container.children.autoHeight.getView() && children.showScroll.propertyView({
+            label: trans("container.showScroll")})}
             {hiddenPropertyView(children)}
           </Section>
           <Section name={sectionNames.style}>{children.container.stylePropertyView()}</Section>

--- a/client/packages/lowcoder/src/comps/comps/triContainerComp/triContainer.tsx
+++ b/client/packages/lowcoder/src/comps/comps/triContainerComp/triContainer.tsx
@@ -39,9 +39,11 @@ const BodyInnerGrid = styled(InnerGrid)<{
   showBorder: boolean;
   backgroundColor: string;
   borderColor: string;
+  showScroll?: boolean;
 }>`
   border-top: ${(props) => `${props.showBorder ? 1 : 0}px solid ${props.borderColor}`};
   flex: 1;
+  overflow: ${(props) => `${props.showScroll ? 'auto' : 'hidden'}`};
   ${(props) => props.backgroundColor && `background-color: ${props.backgroundColor};`}
   border-radius: 0;
 `;
@@ -59,6 +61,7 @@ const FooterInnerGrid = styled(InnerGrid)<{
 
 export type TriContainerProps = TriContainerViewProps & {
   hintPlaceholder?: ReactNode;
+  showScroll?: boolean;
 };
 
 export function TriContainer(props: TriContainerProps) {
@@ -110,6 +113,7 @@ export function TriContainer(props: TriContainerProps) {
             hintPlaceholder={props.hintPlaceholder ?? HintPlaceHolder}
             backgroundColor={style?.background}
             borderColor={style?.border}
+            showScroll={props?.showScroll}
             style={{padding: style.containerbodypadding}}
           />
         </BackgroundColorContext.Provider>

--- a/client/packages/lowcoder/src/i18n/locales/en.ts
+++ b/client/packages/lowcoder/src/i18n/locales/en.ts
@@ -1355,6 +1355,7 @@ export const en = {
   },
   container: {
     title: "Container title",
+    showScroll: "Show scroll",
   },
   drawer: {
     placement: "Drawer placement",

--- a/client/packages/lowcoder/src/i18n/locales/zh.ts
+++ b/client/packages/lowcoder/src/i18n/locales/zh.ts
@@ -1333,6 +1333,7 @@ selectionControl: {
 },
 container: {
     title: "容器标题",
+    showScroll: "显示滚动条",
 },
 drawer: {
     placement: "抽屉位置",


### PR DESCRIPTION
When the body of the container component is in fixed height mode and the height is similar to the internal component, a scroll bar will appear. Adding this option can hide unnecessary scrollbars

![image](https://github.com/lowcoder-org/lowcoder/assets/45591985/1592f077-4f44-4f3f-b854-3cddfea44257)
