### PR TITLE
fix_theme_save_bug

### DIFF
--- a/client/packages/lowcoder/src/pages/setting/theme/themeConstant.tsx
+++ b/client/packages/lowcoder/src/pages/setting/theme/themeConstant.tsx
@@ -30,6 +30,8 @@ export const themeTemplateList = [
       borderRadius: "4px",
       chart: JSON.stringify(ChartTheme, null, 2),
       gridColumns: "24", //Added By Aqib Mirza
+      margin: "3px",
+      padding: "3px",
     },
   },
   {
@@ -45,6 +47,8 @@ export const themeTemplateList = [
       borderRadius: "4px",
       chart: JSON.stringify(ChartYellowTheme, null, 2),
       gridColumns: "24", //Added By Aqib Mirza
+      margin: "3px",
+      padding: "3px",
     },
   },
   {
@@ -60,6 +64,8 @@ export const themeTemplateList = [
       borderRadius: "4px",
       chart: JSON.stringify(ChartGreenTheme, null, 2),
       gridColumns: "24", //Added By Aqib Mirza
+      margin: "3px",
+      padding: "3px",
     },
   },
 ];


### PR DESCRIPTION
Two bugs:
1. When creating a new theme, padding and margin have no default values
2. The save button remains disabled after modification

![image](https://github.com/lowcoder-org/lowcoder/assets/45591985/c31af84c-5179-4ed2-8909-459ff8df3c37)
