### PR TITLE
fix helm template encryption env var names

### DIFF
--- a/deploy/helm/templates/api-service/secrets.yaml
+++ b/deploy/helm/templates/api-service/secrets.yaml
@@ -20,6 +20,6 @@ stringData:
   {{- else }}
   LOWCODER_MONGODB_URL: {{ .Values.mongodb.externalUrl | quote }}
   {{- end }}
-  ELOWCODER_DB_NCRYPTION_PASSWORD: {{ .Values.global.config.encryption.password | default "lowcoder.org" | quote }}
-  ELOWCODER_DB_NCRYPTION_SALT: {{ .Values.global.config.encryption.salt | default "lowcoder.org" | quote }}
+  LOWCODER_DB_ENCRYPTION_PASSWORD: {{ .Values.global.config.encryption.password | default "lowcoder.org" | quote }}
+  LOWCODER_DB_ENCRYPTION_SALT: {{ .Values.global.config.encryption.salt | default "lowcoder.org" | quote }}
   LOWCODER_API_KEY_SECRET: "{{ .Values.global.config.apiKeySecret }}"


### PR DESCRIPTION
## Proposed changes

Looking at the name of the env vars created within the kubernetes secret via Helm and checking the code i suspect the 
to environment variables defining the DB encryption secrets to be named wrong. The letter "E" was moved to the wrong place.

This fix changes the environment names to match the ones in the docker compose yaml files / docker readme / app.json file.

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
