### PR TITLE
Feature To Set Application AS Agency Profile

### DIFF
--- a/server/api-service/lowcoder-domain/src/main/java/org/lowcoder/domain/application/model/Application.java
+++ b/server/api-service/lowcoder-domain/src/main/java/org/lowcoder/domain/application/model/Application.java
@@ -41,6 +41,8 @@ public class Application extends HasIdAndAuditing {
     private final Boolean publicToAll;
     private final Boolean publicToMarketplace;
 
+    private final Boolean agencyProfile;
+
     private Map<String, Object> editingApplicationDSL;
 
     @Transient
@@ -78,6 +80,7 @@ public class Application extends HasIdAndAuditing {
             @JsonProperty("publishedApplicationDSL") Map<String, Object> publishedApplicationDSL,
             @JsonProperty("publicToAll") Boolean publicToAll,
             @JsonProperty("publicToMarketplace") Boolean publicToMarketplace,
+            @JsonProperty("agencyProfile") Boolean agencyProfile,
             @JsonProperty("editingApplicationDSL") Map<String, Object> editingApplicationDSL) {
         this.organizationId = organizationId;
         this.name = name;
@@ -86,6 +89,7 @@ public class Application extends HasIdAndAuditing {
         this.publishedApplicationDSL = publishedApplicationDSL;
         this.publicToAll = publicToAll;
         this.publicToMarketplace = publicToMarketplace;
+        this.agencyProfile = agencyProfile;
         this.editingApplicationDSL = editingApplicationDSL;
     }
 
@@ -111,6 +115,10 @@ public class Application extends HasIdAndAuditing {
 
     public boolean isPublicToMarketplace() {
         return BooleanUtils.toBooleanDefaultIfNull(publicToMarketplace, false);
+    }
+
+    public boolean agencyProfile() {
+        return BooleanUtils.toBooleanDefaultIfNull(agencyProfile, false);
     }
 
     public ApplicationQuery getQueryByViewModeAndQueryId(boolean isViewMode, String queryId) {

--- a/server/api-service/lowcoder-domain/src/main/java/org/lowcoder/domain/application/repository/ApplicationRepository.java
+++ b/server/api-service/lowcoder-domain/src/main/java/org/lowcoder/domain/application/repository/ApplicationRepository.java
@@ -34,9 +34,12 @@ public interface ApplicationRepository extends ReactiveMongoRepository<Applicati
 
     Flux<Application> findByIdIn(List<String> ids);
 
-    @Query(fields = "{_id : 1}")
-    Flux<Application> findByPublicToAllIsTrueAndPublicToMarketplaceIsAndIdIn(Boolean publicToMarketplace, Collection<String> ids);
+    @Query(value = "{$and:[{'publicToAll':true},{'$or':[{'publicToMarketplace':?0},{'agencyProfile':?1}]}, {'_id': { $in: ?2}}]}", fields = "{_id : 1}")
+    Flux<Application> findByPublicToAllIsTrueAndPublicToMarketplaceIsOrAgencyProfileIsAndIdIn
+            (Boolean publicToMarketplace, Boolean agencyProfile, Collection<String> ids);
 
     Flux<Application> findByPublicToAllIsTrueAndPublicToMarketplaceIsTrue();
+
+    Flux<Application> findByPublicToAllIsTrueAndAgencyProfileIsTrue();
 
 }

--- a/server/api-service/lowcoder-domain/src/main/java/org/lowcoder/domain/application/service/ApplicationService.java
+++ b/server/api-service/lowcoder-domain/src/main/java/org/lowcoder/domain/application/service/ApplicationService.java
@@ -107,6 +107,10 @@ public class ApplicationService {
         return repository.findByPublicToAllIsTrueAndPublicToMarketplaceIsTrue();
     }
 
+    public Flux<Application> findAllAgencyProfileApps() {
+        return repository.findByPublicToAllIsTrueAndAgencyProfileIsTrue();
+    }
+
     public Mono<Long> countByOrganizationId(String orgId, ApplicationStatus applicationStatus) {
         return repository.countByOrganizationIdAndApplicationStatus(orgId, applicationStatus);
     }
@@ -158,10 +162,17 @@ public class ApplicationService {
         return mongoUpsertHelper.updateById(application, applicationId);
     }
 
+    public Mono<Boolean> setApplicationAsAgencyProfile(String applicationId, boolean agencyProfile) {
+        Application application = Application.builder()
+                .agencyProfile(agencyProfile)
+                .build();
+        return mongoUpsertHelper.updateById(application, applicationId);
+    }
+
     @NonEmptyMono
     @SuppressWarnings("ReactiveStreamsNullableInLambdaInTransform")
     public Mono<Set<String>> getPublicApplicationIds(Collection<String> applicationIds, Boolean isAnonymous) {
-        return repository.findByPublicToAllIsTrueAndPublicToMarketplaceIsAndIdIn(!isAnonymous, applicationIds)
+        return repository.findByPublicToAllIsTrueAndPublicToMarketplaceIsOrAgencyProfileIsAndIdIn(!isAnonymous, !isAnonymous, applicationIds)
                 .map(HasIdAndAuditing::getId)
                 .collect(Collectors.toSet());
 

--- a/server/api-service/lowcoder-domain/src/main/java/org/lowcoder/domain/permission/model/ResourceAction.java
+++ b/server/api-service/lowcoder-domain/src/main/java/org/lowcoder/domain/permission/model/ResourceAction.java
@@ -25,6 +25,7 @@ public enum ResourceAction {
 
     SET_APPLICATIONS_PUBLIC(ResourceRole.EDITOR, ResourceType.APPLICATION),
     SET_APPLICATIONS_PUBLIC_TO_MARKETPLACE(ResourceRole.EDITOR, ResourceType.APPLICATION),
+    SET_APPLICATIONS_AS_AGENCY_PROFILE(ResourceRole.EDITOR, ResourceType.APPLICATION),
 
     // datasource action
     MANAGE_DATASOURCES(ResourceRole.OWNER, ResourceType.DATASOURCE),

--- a/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/application/ApplicationApiService.java
+++ b/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/application/ApplicationApiService.java
@@ -141,7 +141,7 @@ public class ApplicationApiService {
                 createApplicationRequest.applicationType(),
                 NORMAL,
                 createApplicationRequest.publishedApplicationDSL(),
-                false, false, createApplicationRequest.editingApplicationDSL());
+                false, false, false, createApplicationRequest.editingApplicationDSL());
 
         if (StringUtils.isBlank(application.getOrganizationId())) {
             return deferredError(INVALID_PARAMETER, "ORG_ID_EMPTY");
@@ -504,6 +504,12 @@ public class ApplicationApiService {
         return checkCurrentUserApplicationPermission(applicationId, ResourceAction.SET_APPLICATIONS_PUBLIC_TO_MARKETPLACE)
                 .then(checkApplicationStatus(applicationId, NORMAL))
                 .then(applicationService.setApplicationPublicToMarketplace(applicationId, publicToMarketplace));
+    }
+
+    public Mono<Boolean> setApplicationAsAgencyProfile(String applicationId, boolean agencyProfile) {
+        return checkCurrentUserApplicationPermission(applicationId, ResourceAction.SET_APPLICATIONS_AS_AGENCY_PROFILE)
+                .then(checkApplicationStatus(applicationId, NORMAL))
+                .then(applicationService.setApplicationAsAgencyProfile(applicationId, agencyProfile));
     }
 
     private Map<String, Object> sanitizeDsl(Map<String, Object> applicationDsl) {

--- a/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/application/ApplicationController.java
+++ b/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/application/ApplicationController.java
@@ -91,7 +91,7 @@ public class ApplicationController implements ApplicationEndpoints {
 
     @Override
     public Mono<ResponseView<ApplicationView>> getPublishedApplication(@PathVariable String applicationId) {
-        return applicationApiService.getPublishedApplication(applicationId)
+        return applicationApiService.getPublishedApplication(applicationId, ApplicationRequestType.PUBLIC_TO_ALL)
                 .delayUntil(applicationView -> applicationApiService.updateUserApplicationLastViewTime(applicationId))
                 .delayUntil(applicationView -> businessEventPublisher.publishApplicationCommonEvent(applicationView, VIEW))
                 .map(ResponseView::success);
@@ -99,7 +99,7 @@ public class ApplicationController implements ApplicationEndpoints {
 
     @Override
     public Mono<ResponseView<ApplicationView>> getPublishedMarketPlaceApplication(@PathVariable String applicationId) {
-        return applicationApiService.getPublishedApplication(applicationId)
+        return applicationApiService.getPublishedApplication(applicationId, ApplicationRequestType.PUBLIC_TO_MARKETPLACE)
                 .delayUntil(applicationView -> applicationApiService.updateUserApplicationLastViewTime(applicationId))
                 .delayUntil(applicationView -> businessEventPublisher.publishApplicationCommonEvent(applicationView, VIEW))
                 .map(ResponseView::success);
@@ -107,7 +107,7 @@ public class ApplicationController implements ApplicationEndpoints {
 
     @Override
     public Mono<ResponseView<ApplicationView>> getAgencyProfileApplication(@PathVariable String applicationId) {
-        return applicationApiService.getPublishedApplication(applicationId)
+        return applicationApiService.getPublishedApplication(applicationId, ApplicationRequestType.AGENCY_PROFILE)
                 .delayUntil(applicationView -> applicationApiService.updateUserApplicationLastViewTime(applicationId))
                 .delayUntil(applicationView -> businessEventPublisher.publishApplicationCommonEvent(applicationView, VIEW))
                 .map(ResponseView::success);

--- a/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/application/ApplicationEndpoints.java
+++ b/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/application/ApplicationEndpoints.java
@@ -122,6 +122,15 @@ public interface ApplicationEndpoints
 
 	@Operation(
 			tags = TAG_APPLICATION_MANAGEMENT,
+			operationId = "getAgencyProfileApplicationDataInViewMode",
+			summary = "Get Agency profile Application data in view mode",
+			description = "Retrieve the DSL data of a Lowcoder Application in view-mode by its ID marked as agency profile."
+	)
+	@GetMapping("/{applicationId}/view_agency")
+	public Mono<ResponseView<ApplicationView>> getAgencyProfileApplication(@PathVariable String applicationId);
+
+	@Operation(
+			tags = TAG_APPLICATION_MANAGEMENT,
 		    operationId = "updateApplication",
 		    summary = "Update Application by ID",
 		    description = "Update a Lowcoder Application identified by its ID."
@@ -167,6 +176,15 @@ public interface ApplicationEndpoints
 	)
 	@GetMapping("/marketplace-apps")
 	public Mono<ResponseView<List<MarketplaceApplicationInfoView>>> getMarketplaceApplications(@RequestParam(required = false) Integer applicationType);
+
+	@Operation(
+			tags = TAG_APPLICATION_MANAGEMENT,
+			operationId = "listAgencyProfileApplications",
+			summary = "List agency profile Applications",
+			description = "Retrieve a list of Lowcoder Applications that are set as agency profiles"
+	)
+	@GetMapping("/agency-profiles")
+	public Mono<ResponseView<List<MarketplaceApplicationInfoView>>> getAgencyProfileApplications(@RequestParam(required = false) Integer applicationType);
 
 	@Operation(
 			tags = TAG_APPLICATION_PERMISSIONS,
@@ -231,6 +249,16 @@ public interface ApplicationEndpoints
 	public Mono<ResponseView<Boolean>> setApplicationPublicToMarketplace(@PathVariable String applicationId,
 																  @RequestBody ApplicationPublicToMarketplaceRequest request);
 
+	@Operation(
+			tags = TAG_APPLICATION_MANAGEMENT,
+			operationId = "setApplicationAsAgencyProfile",
+			summary = "Set Application as agency profile",
+			description = "Set a Lowcoder Application identified by its ID as as agency profile but to only logged in users."
+	)
+	@PutMapping("/{applicationId}/agency-profile")
+	public Mono<ResponseView<Boolean>> setApplicationAsAgencyProfile(@PathVariable String applicationId,
+																	 @RequestBody ApplicationAsAgencyProfileRequest request);
+
 
 	public record BatchAddPermissionRequest(String role, Set<String> userIds, Set<String> groupIds) {
     }
@@ -246,6 +274,13 @@ public interface ApplicationEndpoints
 		@Override
 		public Boolean publicToMarketplace() {
 			return BooleanUtils.isTrue(publicToMarketplace);
+		}
+	}
+
+	public record ApplicationAsAgencyProfileRequest(Boolean agencyProfile) {
+		@Override
+		public Boolean agencyProfile() {
+			return BooleanUtils.isTrue(agencyProfile);
 		}
 	}
 

--- a/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/application/ApplicationEndpoints.java
+++ b/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/application/ApplicationEndpoints.java
@@ -284,6 +284,12 @@ public interface ApplicationEndpoints
 		}
 	}
 
+	public enum ApplicationRequestType {
+		PUBLIC_TO_ALL,
+		PUBLIC_TO_MARKETPLACE,
+		AGENCY_PROFILE,
+	}
+
     public record UpdatePermissionRequest(String role) {
     }
 

--- a/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/home/UserHomeApiService.java
+++ b/server/api-service/lowcoder-server/src/main/java/org/lowcoder/api/home/UserHomeApiService.java
@@ -25,4 +25,6 @@ public interface UserHomeApiService {
             @Nullable ApplicationStatus applicationStatus, boolean withContainerSize);
 
     public Flux<MarketplaceApplicationInfoView> getAllMarketplaceApplications(@Nullable ApplicationType applicationType);
+
+    public Flux<MarketplaceApplicationInfoView> getAllAgencyProfileApplications(@Nullable ApplicationType applicationType);
 }


### PR DESCRIPTION
## Proposed changes
- Added support for a new flag "agency_profile" to handle apps that would show up as agency profiles.
- Also added a validation to only allow agency apps to be viewed by the "/view_agency" endpoint, and same for the "view_marketplace" endpoint.

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
