### PR TITLE
optimize /runOpenApi to allow pre-dereferencing OpenAPI Spec

### DIFF
--- a/server/node-service/src/plugins/github/index.ts
+++ b/server/node-service/src/plugins/github/index.ts
@@ -5,6 +5,7 @@ import { OpenAPIV3, OpenAPI } from "openapi-types";
 import { ConfigToType, DataSourcePlugin } from "lowcoder-sdk/dataSource";
 import { runOpenApi } from "../openApi";
 import { parseOpenApi, ParseOpenApiOptions } from "../openApi/parse";
+import SwaggerParser from "@apidevtools/swagger-parser";
 
 const spec = readYaml(path.join(__dirname, "./github.spec.yaml"));
 
@@ -34,6 +35,7 @@ const parseOptions: ParseOpenApiOptions = {
     return _.upperFirst(operation.operationId || "");
   },
 };
+const deRefedSpec = SwaggerParser.dereference(spec);
 
 type DataSourceConfigType = ConfigToType<typeof dataSourceConfig>;
 
@@ -55,13 +57,13 @@ const gitHubPlugin: DataSourcePlugin<any, DataSourceConfigType> = {
       actions,
     };
   },
-  run: function (actionData, dataSourceConfig): Promise<any> {
+  run: async function (actionData, dataSourceConfig, ctx): Promise<any> {
     const runApiDsConfig = {
       url: "",
       serverURL: "https://api.github.com",
       dynamicParamsConfig: dataSourceConfig,
     };
-    return runOpenApi(actionData, runApiDsConfig, spec as OpenAPIV3.Document);
+    return runOpenApi(actionData, runApiDsConfig, spec as OpenAPIV3.Document, undefined, await deRefedSpec);
   },
 };
 

--- a/server/node-service/src/plugins/openApi/index.ts
+++ b/server/node-service/src/plugins/openApi/index.ts
@@ -54,18 +54,28 @@ export async function runOpenApi(
   actionData: ActionDataType,
   dataSourceConfig: DataSourceDataType,
   spec: OpenAPI.Document | MultiOpenApiSpecItem[],
-  defaultHeaders?: Record<string, string>
+  defaultHeaders?: Record<string, string>,
+  openApiSpecDereferenced?: OpenAPI.Document,
 ) {
   const specList = Array.isArray(spec) ? spec : [{ spec, id: "" }];
-  const definitions = await Promise.all(
-    specList.map(async ({ id, spec }) => {
-      const deRefedSpec = await SwaggerParser.dereference(spec);
-      return {
-        def: deRefedSpec,
-        id,
-      };
-    })
-  );
+  let definitions;
+
+  if (!openApiSpecDereferenced) {
+    definitions = await Promise.all(
+      specList.map(async ({id, spec}) => {
+        const deRefedSpec = await SwaggerParser.dereference(spec);
+        return {
+          def: deRefedSpec,
+          id,
+        };
+      })
+    );
+  } else {
+    definitions = [{
+      def: openApiSpecDereferenced,
+      id: "",
+    }]
+  }
   const { actionName, ...otherActionData } = actionData;
   const { serverURL } = dataSourceConfig;
 

--- a/server/node-service/src/plugins/openApi/index.ts
+++ b/server/node-service/src/plugins/openApi/index.ts
@@ -12,11 +12,10 @@ import {
   isFile,
 } from "./util";
 import { badRequest } from "../../common/error";
-import { safeJsonParse } from "../../common/util";
 import { OpenAPI, OpenAPIV2, OpenAPIV3 } from "openapi-types";
 import _ from "lodash";
 import { fetch } from "../../common/fetch";
-import { RequestInit, Response } from "node-fetch";
+import { RequestInit } from "node-fetch";
 
 const dataSourceConfig = {
   type: "dataSource",


### PR DESCRIPTION
This PR fixes an issue where the `openApi` plugin would try to dereference the
OpenAPI spec for each plugin when the plugin is _run_ rather than on
initialization.

I did not attempt to fix the issue for every plugin, I simply wanted to start with
the one that was affecting me the most, the Github plugin. But this PR
adds the capability to allow any OpenAPI plugin to now use a pre-dereferenced
`OpenAPI.Document` instead of de-referencing during runtime. 

# Before: 

`/plugins` averaged `19.472`ms before the change
`/runPluginQuery` averaged `6867.030`ms before the change

```
GET /node-service/api/plugins 200 17.112 ms - 31024
POST /node-service/api/runPluginQuery 200 6622.313 ms - 156023
GET /node-service/api/plugins 200 17.698 ms - 31024
POST /node-service/api/runPluginQuery 200 6632.372 ms - 156023
GET /node-service/api/plugins 200 25.301 ms - 31024
POST /node-service/api/runPluginQuery 200 7055.684 ms - 156023
GET /node-service/api/plugins 200 17.178 ms - 31024
POST /node-service/api/runPluginQuery 200 6835.205 ms - 156023
GET /node-service/api/plugins 200 16.735 ms - 31024
POST /node-service/api/runPluginQuery 200 7005.931 ms - 156023
GET /node-service/api/plugins 200 22.808 ms - 31024
POST /node-service/api/runPluginQuery 200 7050.673 ms - 156023
```

# After:

`/plugins` averaged `20.302`ms after the change
`/runPluginQuery` averaged `1533.787`ms after the change

```
GET /node-service/api/plugins 200 77.839 ms - 31024
POST /node-service/api/runPluginQuery 200 1824.782 ms - 156023
GET /node-service/api/plugins 200 6.849 ms - 31024
POST /node-service/api/runPluginQuery 200 1525.905 ms - 156023
GET /node-service/api/plugins 200 15.647 ms - 31024
POST /node-service/api/runPluginQuery 200 1400.096 ms - 156023
GET /node-service/api/plugins 200 3.265 ms - 31024
POST /node-service/api/runPluginQuery 200 1498.696 ms - 156023
GET /node-service/api/plugins 200 9.287 ms - 31024
POST /node-service/api/runPluginQuery 200 1625.815 ms - 156023
GET /node-service/api/plugins 200 8.925 ms - 31024
POST /node-service/api/runPluginQuery 200 1427.427 ms - 156023
```

That's a 77.67% decrease in runtime for the `/runPluginQuery`, but a 4.27% increase for the `/plugins` query. 
Without the 77ms outlier the results are much nicer:

```
(6.849 ms + 15.647 ms + 3.265 ms + 9.287 ms + 8.925 ms) / 5 = ≈ 8.795 ms
[(19.472 - 8.795) / 19.472] * 100 = ≈ 54.84 %
```

**54.84%** decrease in runtime for the `/plugins` query and a **77.67%** decrease in runtime for the `/runPluginQuery` 