### PR TITLE
docker all-in-one image updates for Debian Bookworm base image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -51,7 +51,7 @@ CMD [ "/bin/bash" , "/lowcoder/api-service/entrypoint.sh" ]
 ##
 FROM ubuntu:jammy as build-node-service
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl ca-certificates build-essential gnupg
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl ca-certificates build-essential gnupg
 
 # Add nodejs repo and keys
 RUN mkdir -p /etc/apt/keyrings \
@@ -83,7 +83,7 @@ RUN chmod +x /lowcoder/node-service/*.sh
 FROM ubuntu:jammy as lowcoder-ce-node-service
 LABEL maintainer="lowcoder"
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl ca-certificates gnupg
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl ca-certificates gnupg
 
 # Add nodejs repo and keys
 RUN mkdir -p /etc/apt/keyrings \
@@ -200,15 +200,9 @@ RUN mkdir -p /etc/apt/keyrings \
 # Install required packages
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y bash gnupg curl lsb-release \
   && curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg \
-  && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb bullseye main" | tee /etc/apt/sources.list.d/redis.list \
+  && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb bookworm main" | tee /etc/apt/sources.list.d/redis.list \
   && curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-archive-keyring.gpg \
-  && echo "deb [signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg arch=amd64,arm64] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list \
-  && if [ "$(dpkg --print-architecture)" = "amd64" ] || [ "$(dpkg --print-architecture)" = "i386" ]; then \
-    curl -sL http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_$(dpkg --print-architecture).deb --output libssl1.1_1.1.1f-1ubuntu2_$(dpkg --print-architecture).deb; \
-  else \
-    curl -sL http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_$(dpkg --print-architecture).deb --output libssl1.1_1.1.1f-1ubuntu2_$(dpkg --print-architecture).deb; \
-  fi \
-  && dpkg -i libssl1.1_1.1.1f-1ubuntu2_$(dpkg --print-architecture).deb \
+  && echo "deb [signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/4.4 main" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list \
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends -y \
       mongodb-org \
       redis \

--- a/deploy/docker/all-in-one/etc/supervisord.conf
+++ b/deploy/docker/all-in-one/etc/supervisord.conf
@@ -4,8 +4,8 @@
 file=/var/run/supervisor.sock   ; (the path to the socket file)
 chmod=0700                       ; sockef file mode (default 0700)
 
-[inet_http_server]         ; inet (TCP) server disabled by default
-port=*:9001        ; (ip_address:port specifier, *:port for all iface)
+;[inet_http_server]         ; inet (TCP) server disabled by default
+;port=*:9001        ; (ip_address:port specifier, *:port for all iface)
 ;username=user              ; (default is no username (open server))
 ;password=123               ; (default is no password (open server))
 
@@ -37,8 +37,8 @@ files = /lowcoder/etc/supervisord/conf-enabled/*.conf
 # ; This event listener is used to capture processes log
 # ; and forward to container log using supervisor_stdout
 # ; Ref: https://github.com/coderanger/supervisor-stdout
-# [eventlistener:stdout] 
-# command = supervisor_stdout 
-# buffer_size = 100 
-# events = PROCESS_LOG 
+# [eventlistener:stdout]
+# command = supervisor_stdout
+# buffer_size = 100
+# events = PROCESS_LOG
 # result_handler = supervisor_stdout:event_handler


### PR DESCRIPTION
## Proposed changes

The currently used base image for the All-In-One image is based on Debian 12 Bookworm.
Some parts of the additional software installation are not adapted to the current distro and use packages build for other versions. 

Another update is for security reasons: disable the `supervisord` network server that was enabled WITHOUT any authentication. The port was not officially exported within the Dockerfile and not mentioned at all in the documentation. Therefor not used.
As it is not needed to run (`supervisorctl` uses unix socket) it should be disabled for security reasons.

People to want to used the network access to supervisord had to explicit export port by themself with current image too and do know what they do - they will probably provide a custom supervisord config with auth by themself than also.

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Remark: current state of "dev" branch do not build. This is not due to this PR, current "dev" is broken because `yarn build` fails with a not working test case (`FAIL src/__test__/allComp.test.tsx`).
This PR is completly unrelated to the failing test.

