### PR TITLE
Use API service health check for k8s deployments

### DIFF
--- a/deploy/helm/templates/api-service/deployment.yaml
+++ b/deploy/helm/templates/api-service/deployment.yaml
@@ -61,12 +61,12 @@ spec:
           livenessProbe:
             initialDelaySeconds: 30
             httpGet:
-              path: /actuator/health
+              path: /api/status/health
               port: lowcoder-api
           readinessProbe:
             initialDelaySeconds: 30
             httpGet:
-              path: /actuator/health
+              path: /api/status/health
               port: lowcoder-api
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
## Proposed changes
This pull request addresses an issue with the lowcoder deployment using the current Helm charts, where the api-service pod restarts due to the readiness probe returning a 404 NOT_FOUND error. The error occurs as follows:

`2024-07-30 00:10:55.579 ERROR o.l.api.framework.exception.GlobalExceptionHandler#lambda$doLog$8:155  GET /actuator/health [parallel-1]:  
org.springframework.web.server.ResponseStatusException: 404 NOT_FOUND`

To resolve this issue, this PR updates the readiness and liveness probes to use the health check endpoint as documented in the [Lowcoder self-hosting setup guide](https://docs.lowcoder.cloud/lowcoder-documentation/setup-and-run/self-hosting#health-checks). 
This change ensures that the probes correctly check the health of the api-service and prevent unnecessary pod restarts.
Since health check endpoint was introduced in v2.4.1, previous lowcoder versions will not work.

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
