### PR TITLE
allow deployment when mongodb/redis.auth.existingSecret is not specified

### DIFF
--- a/deploy/helm/templates/api-service/configMap.yaml
+++ b/deploy/helm/templates/api-service/configMap.yaml
@@ -2,7 +2,7 @@
 {{- $name := include "lowcoder.fullname" . -}}
 {{- $lowcoderDatabase := first .Values.mongodb.auth.databases -}}
 {{- $redisSecret := lookup "v1" "Secret" $nameSpace .Values.redis.auth.existingSecret | default dict -}}
-{{- $redisPassword := (index $redisSecret.data .Values.redis.auth.existingSecretPasswordKey | default "" | b64dec) -}}
+{{- $redisPassword := (index ($redisSecret.data|default dict) .Values.redis.auth.existingSecretPasswordKey | default "" | b64dec) -}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/templates/api-service/deployment.yaml
+++ b/deploy/helm/templates/api-service/deployment.yaml
@@ -61,12 +61,12 @@ spec:
           livenessProbe:
             initialDelaySeconds: 30
             httpGet:
-              path: /actuator/health
+              path: /api/status/health
               port: lowcoder-api
           readinessProbe:
             initialDelaySeconds: 30
             httpGet:
-              path: /actuator/health
+              path: /api/status/health
               port: lowcoder-api
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/templates/api-service/secrets.yaml
+++ b/deploy/helm/templates/api-service/secrets.yaml
@@ -3,7 +3,7 @@
 {{- $mongoPassword := (and .Values.mongodb.auth.passwords (first .Values.mongodb.auth.passwords)) | default "" -}}
 {{- $lowcoderDatabase := first .Values.mongodb.auth.databases -}}
 {{- $mongoSecret := lookup "v1" "Secret" $nameSpace .Values.mongodb.auth.existingSecret | default dict -}}
-{{- $mongoSecretPassword := (index $mongoSecret.data "password" | default "" | b64dec) -}}
+{{- $mongoSecretPassword := (index ($mongoSecret.data | default dict) "password" | default "" | b64dec) -}}
 {{- $mongoServicename := .Values.mongodb.service.nameOverride | default "" -}}
 {{- $externalUrl := .Values.mongodb.service.externalUrl -}}
 


### PR DESCRIPTION
## Proposed changes
Without specifying an existingSecret for mongodb and redis, the following errors occur:
```
Error: INSTALLATION FAILED: template: lowcoder/templates/api-service/configMap.yaml:5:23: executing "lowcoder/templates/api-service/configMap.yaml" at <index $redisSecret.data .Values.redis.auth.existingSecretPasswordKey>: error calling index: index of untyped nil
```
and
```
Error: INSTALLATION FAILED: template: lowcoder/templates/api-service/secrets.yaml:6:29: executing "lowcoder/templates/api-service/secrets.yaml" at <index $mongoSecret.data "password">: error calling index: index of untyped nil
```

This creates a default at the data level as well for when there is no secret at all so that we aren't trying to find index "password" in nil (which is an error) instead of an empty dict (which allows the `default ""` to function because the index-on-nil error doesn't halt execution).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
