### PR TITLE
Add 'Open' event on modal component

### DIFF
--- a/client/packages/lowcoder/src/comps/hooks/modalComp.tsx
+++ b/client/packages/lowcoder/src/comps/hooks/modalComp.tsx
@@ -25,6 +25,7 @@ import { withDefault } from "comps/generators";
 import SliderControl from "../controls/sliderControl";
 
 const EventOptions = [
+  { label: trans("modalComp.open"), value: "open", description: trans("modalComp.openDesc") },
   { label: trans("modalComp.close"), value: "close", description: trans("modalComp.closeDesc") },
 ] as const;
 
@@ -168,6 +169,9 @@ let TmpModalComp = (function () {
               }}
               afterClose={() => {
                 props.toggleClose&&props.onEvent("close");
+              }}
+              afterOpenChange={(open: boolean) => {
+                if (open) props.onEvent("open");
               }}
               zIndex={Layers.modal}
               modalRender={(node) => <ModalStyled $style={props.style}>{node}</ModalStyled>}

--- a/client/packages/lowcoder/src/i18n/locales/en.ts
+++ b/client/packages/lowcoder/src/i18n/locales/en.ts
@@ -2368,6 +2368,8 @@ export const en = {
 
 
   "modalComp": {
+    "open": "Open",
+    "openDesc": "Triggered When the Modal Dialog Box is Opened",
     "close": "Close",
     "closeDesc": "Triggered When the Modal Dialog Box is Closed",
     "openModalDesc": "Open the Dialog Box",


### PR DESCRIPTION
## Proposed changes
Fixes  #978 #1104 by adding event handler to Modal component, so actions can be performed after Modal dialog is shown.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
This is pretty minor change in the code. As this is my first contribution directly to the codebase I am not sure if this requires some additional changes. I've used antd 'afterOpenChange' event handler to implement this, which has a sideeffect that it only starts after the modal is rendered, but I think this is not an issue in most cases.
