### PR TITLE
[FIX] Hide text-size property for Markdown Column Type in Table #1601

### DIFF
--- a/client/packages/lowcoder/src/comps/comps/tableComp/column/tableColumnComp.tsx
+++ b/client/packages/lowcoder/src/comps/comps/tableComp/column/tableColumnComp.tsx
@@ -356,7 +356,7 @@ export class ColumnComp extends ColumnInitComp {
               preInputNode: <StyledBorderRadiusIcon as={IconRadius} title="" />,
               placeholder: '3px',
             })}
-            {this.children.textSize.propertyView({
+            {columnType !== 'markdown' && this.children.textSize.propertyView({
               label: trans('style.textSize'),
               preInputNode: <StyledTextSizeIcon as={TextSizeIcon} title="" />,
               placeholder: '14px',


### PR DESCRIPTION
## Proposed changes
This PR hides the "text-size" property when Markdown column type is selected for Table #1601

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [x] Manual testing and this fix doesn't break any existing functionality
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
