### PR TITLE
[Fix]: Workspace switch submenu overflow for Mobile Screens

### DIFF
--- a/client/packages/lowcoder/src/pages/common/profileDropdown.tsx
+++ b/client/packages/lowcoder/src/pages/common/profileDropdown.tsx
@@ -224,7 +224,7 @@ export default function ProfileDropdown(props: DropDownProps) {
     const switchOrgMenu = {
       key: 'switchOrg',
       label: trans("profile.switchOrg"),
-      popupOffset: [4, -12],
+      popupOffset: checkIsMobile(window.innerWidth) ? [-200, 36] : [4, -12],
       children: [
         {
           key: 'joinedOrg',


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue especially for **_mobile screens_** when we switch the Organization/Workspaces from the Profile Dropdown, before this fix Workspace submenu shows partially/overflows, read more about this issue #1414 


## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
