### PR TITLE
[Fix]: backward compatibility for button, link and links column types

### DIFF
--- a/client/packages/lowcoder/src/comps/comps/tableComp/column/simpleColumnTypeComps.tsx
+++ b/client/packages/lowcoder/src/comps/comps/tableComp/column/simpleColumnTypeComps.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useMemo } from "react";
 import { CSSProperties } from "react";
 import { RecordConstructorToComp } from "lowcoder-core";
 import { ToViewReturn } from "@lowcoder-ee/comps/generators/multi";
+import { clickEvent, eventHandlerControl } from "comps/controls/eventHandlerControl";
 
 export const ColumnValueTooltip = trans("table.columnValueTooltip");
 
@@ -31,10 +32,13 @@ export const ButtonTypeOptions = [
   },
 ] as const;
 
+const ButtonEventOptions = [clickEvent] as const;
+
 const childrenMap = {
   text: StringControl,
   buttonType: dropdownControl(ButtonTypeOptions, "primary"),
   onClick: ActionSelectorControlInContext,
+  onEvent: eventHandlerControl(ButtonEventOptions),
   loading: BoolCodeControl,
   disabled: BoolCodeControl,
   prefixIcon: IconControl,
@@ -49,8 +53,11 @@ const ButtonStyled = React.memo(({ props }: { props: ToViewReturn<RecordConstruc
   const iconOnly = !hasText && (hasPrefixIcon || hasSuffixIcon);
 
   const handleClick = useCallback((e: React.MouseEvent) => {
+    // Trigger legacy onClick action for backward compatibility
     props.onClick?.();
-  }, [props.onClick]);
+    // Trigger new event handlers
+    props.onEvent?.("click");
+  }, [props.onClick, props.onEvent]);
 
   const buttonStyle = useMemo(() => ({
     margin: 0,
@@ -82,29 +89,37 @@ export const ButtonComp = (function () {
     (props) => <ButtonStyled props={props} />,
     (nodeValue) => nodeValue.text.value
   )
-    .setPropertyViewFn((children) => (
-      <>
-        {children.text.propertyView({
-          label: trans("table.columnValue"),
-          tooltip: ColumnValueTooltip,
-        })}
-        {children.prefixIcon.propertyView({
-          label: trans("button.prefixIcon"),
-        })}
-        {children.suffixIcon.propertyView({
-          label: trans("button.suffixIcon"),
-        })}
-        {children.buttonType.propertyView({
-          label: trans("table.type"),
-          radioButton: true,
-        })}
-        {loadingPropertyView(children)}
-        {disabledPropertyView(children)}
-        {children.onClick.propertyView({
-          label: trans("table.action"),
-          placement: "table",
-        })}
-      </>
-    ))
+    .setPropertyViewFn((children) => {
+      // Check if there's a legacy action configured
+      const hasLegacyAction = children.onClick.getView() && 
+        typeof children.onClick.getView() === 'function' &&
+        children.onClick.displayName() !== trans("eventHandler.incomplete");
+
+      return (
+        <>
+          {children.text.propertyView({
+            label: trans("table.columnValue"),
+            tooltip: ColumnValueTooltip,
+          })}
+          {children.prefixIcon.propertyView({
+            label: trans("button.prefixIcon"),
+          })}
+          {children.suffixIcon.propertyView({
+            label: trans("button.suffixIcon"),
+          })}
+          {children.buttonType.propertyView({
+            label: trans("table.type"),
+            radioButton: true,
+          })}
+          {loadingPropertyView(children)}
+          {disabledPropertyView(children)}
+          {children.onEvent.propertyView()}
+          {hasLegacyAction && children.onClick.propertyView({
+            label: trans("table.action"),
+            placement: "table",
+          })}
+        </>
+      );
+    })
     .build();
 })();

--- a/client/packages/lowcoder/src/comps/comps/tableComp/column/simpleColumnTypeComps.tsx
+++ b/client/packages/lowcoder/src/comps/comps/tableComp/column/simpleColumnTypeComps.tsx
@@ -13,7 +13,6 @@ import React, { useCallback, useEffect, useMemo } from "react";
 import { CSSProperties } from "react";
 import { RecordConstructorToComp } from "lowcoder-core";
 import { ToViewReturn } from "@lowcoder-ee/comps/generators/multi";
-import { clickEvent, eventHandlerControl } from "comps/controls/eventHandlerControl";
 
 export const ColumnValueTooltip = trans("table.columnValueTooltip");
 
@@ -32,12 +31,9 @@ export const ButtonTypeOptions = [
   },
 ] as const;
 
-const ButtonEventOptions = [clickEvent] as const;
-
 const childrenMap = {
   text: StringControl,
   buttonType: dropdownControl(ButtonTypeOptions, "primary"),
-  onEvent: eventHandlerControl(ButtonEventOptions),
   onClick: ActionSelectorControlInContext,
   loading: BoolCodeControl,
   disabled: BoolCodeControl,
@@ -54,8 +50,7 @@ const ButtonStyled = React.memo(({ props }: { props: ToViewReturn<RecordConstruc
 
   const handleClick = useCallback((e: React.MouseEvent) => {
     props.onClick?.();
-    // props.onEvent?.("click");
-  }, [props.onClick, props.onEvent]);
+  }, [props.onClick]);
 
   const buttonStyle = useMemo(() => ({
     margin: 0,
@@ -105,7 +100,6 @@ export const ButtonComp = (function () {
         })}
         {loadingPropertyView(children)}
         {disabledPropertyView(children)}
-        {/* {children.onEvent.propertyView()} */}
         {children.onClick.propertyView({
           label: trans("table.action"),
           placement: "table",


### PR DESCRIPTION
## Proposed changes

This PR adds backward compatibility for button, link and links column types, the reason it was needed because button, and links has "action" in UI, if user is already using "action" then both options will show up, unless they disable the "action"
once they don't use "action" action property will be removed from UI and they can start using the new Event Handlers approach

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
