### PR TITLE
[Fix]: #1862 able to edit the usergroups without navigate

### DIFF
--- a/client/packages/lowcoder/src/pages/setting/permission/permissionList.tsx
+++ b/client/packages/lowcoder/src/pages/setting/permission/permissionList.tsx
@@ -187,7 +187,14 @@ export default function PermissionSetting(props: PermissionSettingProps) {
           scroll={{ x: "100%" }}
           pagination={false}
           onRow={(record) => ({
-            onClick: () => history.push(buildGroupId((record as DataItemInfo).key)),
+            onClick: (e) => {
+              // Don't navigate if this row is in rename mode
+              if ((record as DataItemInfo).key === needRenameId) {
+                e.stopPropagation();
+                return;
+              }
+              history.push(buildGroupId((record as DataItemInfo).key));
+            },
           })}
           columns={[
             {


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue when we try to rename/edit the UserGroups, it takes us to the different page
more details on -> #1862 

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
