### PR TITLE
[Fix]: #1935 add instant save for boolean, select and switch

### DIFF
--- a/client/packages/lowcoder/src/comps/comps/tableComp/column/columnTypeComps/columnBooleanComp.tsx
+++ b/client/packages/lowcoder/src/comps/comps/tableComp/column/columnTypeComps/columnBooleanComp.tsx
@@ -64,6 +64,7 @@ type CheckBoxEditPropsType = {
   value: boolean;
   onChange: (value: boolean) => void;
   onChangeEnd: () => void;
+  onImmediateSave?: (value: boolean) => void;
 };
 
 // Memoized checkbox edit component
@@ -92,8 +93,13 @@ const CheckBoxEdit = React.memo((props: CheckBoxEditPropsType) => {
 
   const handleChange = useCallback((e: CheckboxChangeEvent) => {
     if (!mountedRef.current) return;
-    props.onChange(e.target.checked);
-  }, [props.onChange]);
+    const newValue = e.target.checked;
+    props.onChange(newValue);
+    // Use immediate save to show Save Changes button without exiting edit mode
+    if (props.onImmediateSave) {
+      props.onImmediateSave(newValue);
+    }
+  }, [props.onChange, props.onImmediateSave]);
 
   return (
     <Wrapper
@@ -171,6 +177,7 @@ export const BooleanComp = (function () {
           value={props.value}
           onChange={props.onChange}
           onChangeEnd={props.onChangeEnd}
+          onImmediateSave={props.onImmediateSave}
         />
       );
     })

--- a/client/packages/lowcoder/src/comps/comps/tableComp/column/columnTypeComps/columnSelectComp.tsx
+++ b/client/packages/lowcoder/src/comps/comps/tableComp/column/columnTypeComps/columnSelectComp.tsx
@@ -124,6 +124,7 @@ type SelectEditProps = {
   initialValue: string;
   onChange: (value: string) => void;
   onChangeEnd: () => void;
+  onImmediateSave?: (value: string) => void;
   options: any[];
   onMainEvent?: (eventName: string) => void;
 };
@@ -146,6 +147,11 @@ const SelectEdit = React.memo((props: SelectEditProps) => {
     props.onChange(val);
     setCurrentValue(val);
     
+    // Use immediate save to show Save Changes button without exiting edit mode
+    if (props.onImmediateSave) {
+      props.onImmediateSave(val);
+    }
+    
     // Trigger the specific option's event handler
     const selectedOption = props.options.find(option => option.value === val);
     if (selectedOption?.onEvent) {
@@ -156,7 +162,7 @@ const SelectEdit = React.memo((props: SelectEditProps) => {
     if (props.onMainEvent) {
       props.onMainEvent("click");
     }
-  }, [props.onChange, props.options, props.onMainEvent]);
+  }, [props.onChange, props.onImmediateSave, props.options, props.onMainEvent]);
 
   const handleEvent = useCallback(async (eventName: string) => {
     if (!mountedRef.current) return [] as unknown[];
@@ -209,6 +215,7 @@ export const ColumnSelectComp = (function () {
             options={props.otherProps?.options || []}
             onChange={props.onChange}
             onChangeEnd={props.onChangeEnd}
+            onImmediateSave={props.onImmediateSave}
             onMainEvent={props.otherProps?.onEvent}
           />
         </Wrapper>

--- a/client/packages/lowcoder/src/comps/comps/tableComp/column/columnTypeComps/columnSwitchComp.tsx
+++ b/client/packages/lowcoder/src/comps/comps/tableComp/column/columnTypeComps/columnSwitchComp.tsx
@@ -144,6 +144,10 @@ export const SwitchComp = (function () {
             disabled={false}
             onChange={(checked, e) => {
               props.onChange(checked);
+              // Use immediate save to show Save Changes button without exiting edit mode
+              if (props.onImmediateSave) {
+                props.onImmediateSave(checked);
+              }
               props.otherProps?.onEvent?.("change");
               props.otherProps?.onEvent?.(checked ? "true" : "false");
             }}


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue for the boolean, switch and select type to save changes immediately 
more details on -> #1935 

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
