### PR TITLE
[Fix]: #2022 Tab spacing issue in code editor

### DIFF
--- a/client/packages/lowcoder/src/base/codeEditor/extensions.tsx
+++ b/client/packages/lowcoder/src/base/codeEditor/extensions.tsx
@@ -27,7 +27,7 @@ import {
   foldKeymap,
   indentOnInput,
 } from "@codemirror/language";
-import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap, insertTab, indentLess, indentMore } from "@codemirror/commands";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 import { Diagnostic, linter, lintKeymap } from "@codemirror/lint";
 import { type EditorState, Prec } from "@codemirror/state";
@@ -282,7 +282,20 @@ export function useFocusExtension(onFocus?: (focused: boolean) => void): [Extens
 }
 
 function indentWithTabExtension(open?: boolean) {
-  return open ?? true ? keymap.of([indentWithTab]) : [];
+  if (!(open ?? true)) return [];
+  return keymap.of([
+    {
+      key: "Tab",
+      run: (view: EditorView) => {
+        const { main } = view.state.selection;
+        if (!main.empty && main.from !== main.to) {
+          return indentMore(view);
+        }
+        return insertTab(view);
+      },
+    },
+    { key: "Shift-Tab", run: indentLess },
+  ]);
 }
 
 export function lineNoExtension(showLineNumber?: boolean) {
@@ -493,26 +506,26 @@ export function useExtensions(props: CodeEditorProps) {
       basicSetup,
       defaultTheme,
       highlightJsExt,
-      autocompletionExtension,
       focusExtension,
       lineNoExt,
       languageExt,
       onChangeExt,
       placeholderExt,
       indentWithTabExt,
+      autocompletionExtension,
       tooltipExt,
       lintExt,
       iconExt,
     ],
     [
       highlightJsExt,
-      autocompletionExtension,
       focusExtension,
       lineNoExt,
       languageExt,
       onChangeExt,
       placeholderExt,
       indentWithTabExt,
+      autocompletionExtension,
       tooltipExt,
       lintExt,
       iconExt,


### PR DESCRIPTION
## Proposed changes
This PR fixes the Tab spacing issue in code editors, it also adds the functionality to properly de-indent the code via Shift+Tab
more details on -> #2022


## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
