### PR TITLE
[Feat]: #2113 add able to run queries on toast close/dismiss

### DIFF
--- a/client/packages/lowcoder/src/comps/hooks/toastComp.ts
+++ b/client/packages/lowcoder/src/comps/hooks/toastComp.ts
@@ -6,6 +6,8 @@ import { JSONObject } from "../../util/jsonTypes";
 import { trans } from "i18n";
 import { notificationInstance } from "lowcoder-design";
 import type { ArgsProps, NotificationPlacement } from "antd/es/notification/interface";
+import { executeQueryAction, routeByNameAction } from "lowcoder-core";
+import type { DispatchType } from "lowcoder-core";
 
 const params: ParamsConfig = [
   { name: "text", type: "string" },
@@ -14,16 +16,23 @@ const params: ParamsConfig = [
 
 const showNotification = (
   params: EvalParamType[], 
-  level: "open" | "info" | "success" | "warning" | "error"
+  level: "open" | "info" | "success" | "warning" | "error",
+  dispatch?: DispatchType
 ) => {
   const text = params?.[0] as string;
   const options = (params?.[1] as JSONObject) || {};
 
-  const { message , duration, id, placement, dismissible } = options;
+  const { message, duration, id, placement, dismissible, onClose } = options;
 
   const closeIcon: boolean | undefined = dismissible === true ? undefined : (dismissible === false ? false : undefined);
 
   const durationNumberOrNull: number | null = typeof duration === 'number' ? duration : null;
+
+  const onCloseCallback = (): void => {
+    if (onClose && typeof onClose === 'string' && dispatch) {
+      dispatch(routeByNameAction(onClose, executeQueryAction({})));
+    }
+  };
 
   const notificationArgs: ArgsProps = {
     message: text,
@@ -32,6 +41,7 @@ const showNotification = (
     key: id as React.Key,
     placement: placement as NotificationPlacement ?? "bottomRight",
     closeIcon: closeIcon as boolean,
+    onClose: onCloseCallback,
   };
 
   // Use notificationArgs to trigger the notification
@@ -63,31 +73,31 @@ ToastComp = withMethodExposing(ToastComp, [
   {
     method: { name: "open", description: trans("toastComp.info"), params: params },
     execute: (comp, params) => {
-      showNotification(params, "open");
+      showNotification(params, "open", comp.dispatch);
     },
   },
   {
     method: { name: "info", description: trans("toastComp.info"), params: params },
     execute: (comp, params) => {
-      showNotification(params, "info");
+      showNotification(params, "info", comp.dispatch);
     },
   },
   {
     method: { name: "success", description: trans("toastComp.success"), params: params },
     execute: (comp, params) => {
-      showNotification(params, "success");
+      showNotification(params, "success", comp.dispatch);
     },
   },
   {
     method: { name: "warn", description: trans("toastComp.warn"), params: params },
     execute: (comp, params) => {
-      showNotification(params, "warning");
+      showNotification(params, "warning", comp.dispatch);
     },
   },
   {
     method: { name: "error", description: trans("toastComp.error"), params: params },
     execute: (comp, params) => {
-      showNotification(params, "error");
+      showNotification(params, "error", comp.dispatch);
     },
   },
 ]);


### PR DESCRIPTION
## Proposed changes
This PR adds the ability to run queries on the dismissal of the toast
more details on the -> #2113 

How to use:
```
toast.success("Task completed!", {
 duration: 0, // specify 0, to always show the Toast
 onClose: "closeQuery"	// this has to be a string, and will run on Auto Close /  Manual Dismissal 
})

```

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
