### PR TITLE
[Fix]: #2118 table download event override

### DIFF
--- a/client/packages/lowcoder/src/comps/comps/tableComp/tableCompView.tsx
+++ b/client/packages/lowcoder/src/comps/comps/tableComp/tableCompView.tsx
@@ -294,8 +294,13 @@ export const TableCompView = React.memo((props: {
         )
       }
       onDownload={() => {
-        handleChangeEvent("download");
-        onDownload(`${compName}-data`)
+        if (compChildren.onEvent.isBind("download")) {
+          // Custom download handler exists
+          handleChangeEvent("download");
+        } else {
+          // Download default CSV 
+          onDownload(`${compName}-data`);
+        }
       }}
       hasChange={hasChange}
       onSaveChanges={() => handleChangeEvent("saveChanges")}


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue when the Table Download event has been selected, the default table still gets downloaded 
more details on the -> #2118 

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
