### PR TITLE
fix: datePicker moves back to the current month glitch

### DIFF
--- a/client/packages/lowcoder/src/comps/comps/dateComp/dateComp.tsx
+++ b/client/packages/lowcoder/src/comps/comps/dateComp/dateComp.tsx
@@ -282,9 +282,6 @@ const DatePickerTmpCmp = new UICompBuilder(childrenMap, (props) => {
             props.onEvent
           );
         }}
-        onPanelChange={() => {
-          handleDateChange("", props.value.onChange, noop);
-        }}
         onFocus={() => props.onEvent("focus")}
         onBlur={() => props.onEvent("blur")}
         suffixIcon={hasIcon(props.suffixIcon) && props.suffixIcon}

--- a/client/packages/lowcoder/src/comps/comps/dateComp/dateUIView.tsx
+++ b/client/packages/lowcoder/src/comps/comps/dateComp/dateUIView.tsx
@@ -55,7 +55,7 @@ const StyledAntdSelect = styled(AntdSelect)`
 export interface DataUIViewProps extends DateCompViewProps {
   value?: DatePickerProps<Dayjs>['value'];
   onChange: DatePickerProps<Dayjs>['onChange'];
-  onPanelChange: () => void;
+  onPanelChange?: () => void;
   onClickDateTimeZone:(value:any)=>void;
   tabIndex?: number;
   $disabledStyle?: DisabledInputStyleType;


### PR DESCRIPTION
## Proposed changes

This PR fixes the issue of the datepicker when it takes the user back to the current month 
https://lowcoder.slack.com/archives/C01MBD80DB9/p1776889334281449

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
