### PR TITLE
[Feat]: Stretch canvas height for fixed-row layout

### DIFF
--- a/client/packages/lowcoder/src/comps/comps/appSettingsComp.tsx
+++ b/client/packages/lowcoder/src/comps/comps/appSettingsComp.tsx
@@ -221,6 +221,7 @@ const childrenMap = {
   gridRowCount: withDefault(NumberControl, DEFAULT_ROW_COUNT),
   gridPaddingX: withDefault(NumberControl, 0),
   gridPaddingY: withDefault(NumberControl, 0),
+  gridStretchHeight: withDefault(BoolControl, false),
   gridBg: ColorControl,
   gridBgImage: StringControl,
   gridBgImageRepeat: StringControl,
@@ -355,6 +356,7 @@ function AppCanvasSettingsModal(props: ChildrenInstance) {
     gridColumns,
     gridRowHeight,
     gridRowCount,
+    gridStretchHeight,
     gridPaddingX,
     gridPaddingY,
     gridBg,
@@ -477,6 +479,9 @@ function AppCanvasSettingsModal(props: ChildrenInstance) {
           {!isAggregation && gridRowCount.propertyView({
             label: trans("appSetting.gridRowCount"),
             placeholder: 'Infinity',
+          })}
+          {gridRowCount.getView() !== DEFAULT_ROW_COUNT && gridStretchHeight.propertyView({
+            label: "Stretch canvas to available height",
           })}
           {gridPaddingX.propertyView({
             label: trans("appSetting.gridPaddingX"),

--- a/client/packages/lowcoder/src/comps/comps/gridLayoutComp/canvasView.test.ts
+++ b/client/packages/lowcoder/src/comps/comps/gridLayoutComp/canvasView.test.ts
@@ -1,0 +1,19 @@
+import { DEFAULT_ROW_COUNT } from "@lowcoder-ee/layout/calculateUtils";
+import {
+  shouldShowStretchCanvasHeight,
+  shouldStretchCanvasHeight,
+} from "./canvasView";
+
+describe("canvas stretch height helpers", () => {
+  it("shows stretch only for fixed row count", () => {
+    expect(shouldShowStretchCanvasHeight(DEFAULT_ROW_COUNT)).toBe(false);
+    expect(shouldShowStretchCanvasHeight(24)).toBe(true);
+  });
+
+  it("enables stretch only in runtime for fixed row count", () => {
+    expect(shouldStretchCanvasHeight(DEFAULT_ROW_COUNT, true, true)).toBe(false);
+    expect(shouldStretchCanvasHeight(24, false, true)).toBe(false);
+    expect(shouldStretchCanvasHeight(24, true, false)).toBe(false);
+    expect(shouldStretchCanvasHeight(24, true, true)).toBe(true);
+  });
+});

--- a/client/packages/lowcoder/src/comps/comps/gridLayoutComp/canvasView.tsx
+++ b/client/packages/lowcoder/src/comps/comps/gridLayoutComp/canvasView.tsx
@@ -27,6 +27,7 @@ import { getBackgroundStyle } from "@lowcoder-ee/util/styleUtils";
 const UICompContainer = styled.div<{
   $maxWidth?: number;
   $rowCount?: number;
+  $fillHeight?: boolean;
   readOnly?: boolean;
   $bgColor: string;
   $bgImage?: string;
@@ -35,8 +36,8 @@ const UICompContainer = styled.div<{
   $bgImageOrigin?: string;
   $bgImagePosition?: string;
 }>`
-  height: auto;
-  min-height: ${props => props.$rowCount === Infinity ? '100%' : 'auto'};
+  height: ${props => props.$fillHeight ? '100%' : 'auto'};
+  min-height: ${props => props.$fillHeight ? '0' : props.$rowCount === Infinity ? '100%' : 'auto'};
   margin: 0 auto;
   max-width: ${(props) => props.$maxWidth || 1600}px;
   
@@ -67,6 +68,18 @@ const gridLayoutCanvasProps = {
   autoHeight: true,
   isCanvas: true,
 };
+
+export function shouldShowStretchCanvasHeight(rowCount: number) {
+  return rowCount !== DEFAULT_ROW_COUNT;
+}
+
+export function shouldStretchCanvasHeight(
+  rowCount: number,
+  readOnly: boolean,
+  gridStretchHeight?: boolean
+) {
+  return readOnly && Boolean(gridStretchHeight) && rowCount !== DEFAULT_ROW_COUNT;
+}
 
 function getDragSelectedNames(
   items: GridItemsType,
@@ -176,7 +189,7 @@ export const CanvasView = React.memo((props: ContainerBaseProps) => {
 
   const externalState = useContext(ExternalEditorContext);
   const {
-    readOnly,
+    readOnly = false,
     appType,
     rootContainerExtraHeight = DEFAULT_EXTRA_HEIGHT,
     rootContainerPadding,
@@ -271,6 +284,10 @@ export const CanvasView = React.memo((props: ContainerBaseProps) => {
       || defaultTheme?.gridRowCount
       || DEFAULT_ROW_COUNT;
   }, [preventStylesOverwriting, appSettings, currentTheme, defaultTheme]);
+  const isStretchCanvasHeight = useMemo(
+    () => shouldStretchCanvasHeight(defaultRowCount ?? DEFAULT_ROW_COUNT, readOnly, (appSettings as any).gridStretchHeight),
+    [appSettings, defaultRowCount, readOnly]
+  );
 
   const defaultContainerPadding: [number, number] = useMemo(() => {
     const DEFAULT_PADDING = isMobile ? DEFAULT_MOBILE_PADDING : DEFAULT_CONTAINER_PADDING;
@@ -305,10 +322,11 @@ export const CanvasView = React.memo((props: ContainerBaseProps) => {
 
   if (readOnly) {
     return (
-      <UICompContainer
-        $maxWidth={maxWidth}
-        $rowCount={defaultRowCount}
-        readOnly={true}
+        <UICompContainer
+          $maxWidth={maxWidth}
+          $rowCount={defaultRowCount}
+          $fillHeight={isStretchCanvasHeight}
+          readOnly={true}
         className={CNRootContainer}
         $bgColor={bgColor}
         $bgImage={bgImage}
@@ -324,6 +342,9 @@ export const CanvasView = React.memo((props: ContainerBaseProps) => {
             {...props}
             positionParams={positionParams}
             {...gridLayoutCanvasProps}
+            autoHeight={!isStretchCanvasHeight}
+            rowCount={defaultRowCount}
+            isRowCountLocked={isStretchCanvasHeight}
             bgColor={bgColor}
             radius="0px"
             emptyRows={defaultRowCount}
@@ -341,6 +362,7 @@ export const CanvasView = React.memo((props: ContainerBaseProps) => {
         <UICompContainer
           $maxWidth={maxWidth}
           $rowCount={defaultRowCount}
+          $fillHeight={isStretchCanvasHeight}
           className={CNRootContainer}
           $bgColor={bgColor}
           $bgImage={bgImage}
@@ -360,6 +382,9 @@ export const CanvasView = React.memo((props: ContainerBaseProps) => {
                 overflow={rootContainerOverflow}
                 {...props}
                 {...gridLayoutCanvasProps}
+                autoHeight={!isStretchCanvasHeight}
+                rowCount={defaultRowCount}
+                isRowCountLocked={isStretchCanvasHeight}
                 dragSelectedComps={dragSelectedComps}
                 scrollContainerRef={scrollContainerRef}
                 isDroppable={!isModule}

--- a/client/packages/lowcoder/src/pages/editor/editorView.tsx
+++ b/client/packages/lowcoder/src/pages/editor/editorView.tsx
@@ -116,6 +116,9 @@ const Height100Div = lazy(
   () => import('pages/common/styledComponent')
     .then(module => ({default: module.Height100Div}))
 );
+const PreviewContainer = styled.div`
+  height: 100%;
+`;
 const LeftPanel = lazy(
   () => import('pages/common/styledComponent')
     .then(module => ({default: module.LeftPanel}))
@@ -539,14 +542,14 @@ function EditorView(props: EditorViewProps) {
             deviceType={editorState.deviceType}
             deviceOrientation={editorState.deviceOrientation}
           >
-            <div id={PreviewContainerID}>
+            <PreviewContainer id={PreviewContainerID}>
               {uiComp.getView()}
-            </div>
+            </PreviewContainer>
         </DeviceWrapper>
       ) : (
-        <div id={PreviewContainerID}>
+        <PreviewContainer id={PreviewContainerID}>
           {uiComp.getView()}
-        </div>
+        </PreviewContainer>
       )
     )
   }, [
@@ -794,4 +797,3 @@ function EditorView(props: EditorViewProps) {
 export default React.memo(EditorView, (prevProps, newProps) => {
   return isEqual(prevProps, newProps);
 });
-


### PR DESCRIPTION
## Proposed changes

Add a stretch mode for canvas height in fixed-row layouts and expose it through a new canvas setting.

This is intended to support responsive canvas layouts where the editor can fill the available viewport height instead of staying constrained to a fixed canvas height.

This change:
- adds a new `gridStretchHeight` app setting for canvas height stretching
- keeps the runtime behavior constrained to read-only canvas rendering
- extracts the stretch decision into small pure helpers
- adds unit coverage for the new behavior

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This change is intentionally limited to the canvas path for now, but it can be a starting point toward unifying row and column sizing behavior, and eventually the container model, under a shared `fixed` / `grow` / `stretch` approach.