### PR TITLE
fix: jsquery prepared query

### DIFF
--- a/client/packages/lowcoder/src/comps/queries/libraryQuery.tsx
+++ b/client/packages/lowcoder/src/comps/queries/libraryQuery.tsx
@@ -2,7 +2,6 @@ import { default as LoadingOutlined } from "@ant-design/icons/LoadingOutlined";
 import { default as Spin } from "antd/es/spin";
 import DataSourceIcon from "components/DataSourceIcon";
 import { ContextControlType, ContextJsonControl } from "comps/controls/contextCodeControl";
-import { FunctionControl } from "comps/controls/codeControl";
 import { trans } from "i18n";
 import {
   CompAction,
@@ -42,8 +41,6 @@ import { toQueryView } from "./queryCompUtils";
 import { getGlobalSettings } from "comps/utils/globalSettings";
 import { QUERY_EXECUTION_ERROR, QUERY_EXECUTION_OK } from "../../constants/queryConstants";
 import type { SandBoxOption } from "lowcoder-core/src/eval/utils/evalScript";
-import { QueryLibraryApi } from "@lowcoder-ee/api/queryLibraryApi";
-import { validateResponse } from "@lowcoder-ee/api/apiUtils";
 import { JSONValue } from "@lowcoder-ee/util/jsonTypes";
 
 const NoInputsWrapper = styled.div`
@@ -132,7 +129,6 @@ type QueryLibraryUpdateAction = {
 const childrenMap = {
   libraryQueryId: valueComp<string>(""),
   libraryQueryRecordId: valueComp<string>("latest"),
-  libraryQueryType: valueComp<string>(""),
   libraryQueryDSL: valueComp<JSONValue>(null),
   inputs: InputsComp,
   error: stateComp<string>(""),
@@ -146,7 +142,6 @@ export const LibraryQuery = class extends LibraryQueryBase {
   readonly isReady: boolean = false;
 
   private value: DataType | undefined;
-  private queryInfo: any = null;
 
   constructor(params: CompParams<DataType>) {
     super(params);
@@ -154,10 +149,8 @@ export const LibraryQuery = class extends LibraryQueryBase {
   }
 
   override getView() {
-    // Check if this is a JS query
     const queryInfo = this.children.libraryQueryDSL.getView() as any;
-    const queryType = this.children.libraryQueryType.getView() as any;
-    if (queryType === "js") {
+    if (queryInfo?.query?.compType === "js") {
       return async (props: any) => {
         try {
           const { orgCommonSettings } = getGlobalSettings();
@@ -187,7 +180,7 @@ export const LibraryQuery = class extends LibraryQueryBase {
                 return current ?? match;
               });
             }
-            
+
             acc[name] = isDynamicSegment(unevaledValue) ? value : unevaledValue;
             return acc;
           }, {} as Record<string, any>);
@@ -231,10 +224,12 @@ export const LibraryQuery = class extends LibraryQueryBase {
 
   override reduce(action: CompAction): this {
     if (isMyCustomAction<QueryLibraryUpdateAction>(action, "queryLibraryUpdate")) {
-      const isJSQuery = this.children.libraryQueryType.getView() === 'js'
-      const queryDSL = isJSQuery ? action.value?.dsl : null;
-      const queryDSLValue  = this.children.libraryQueryDSL.reduce(this.children.libraryQueryDSL.changeValueAction(queryDSL))
-      
+      const fetchedDSL = action.value?.dsl;
+      const queryDSL = fetchedDSL?.query?.compType === "js" ? fetchedDSL : null;
+      const queryDSLValue = this.children.libraryQueryDSL.reduce(
+        this.children.libraryQueryDSL.changeValueAction(queryDSL)
+      );
+
       const inputs = this.children.inputs.setInputs(action.value?.dsl?.["inputs"] ?? []);
       return setFieldsNoTypeCheck(this, {
         children: { ...this.children, inputs: inputs, libraryQueryDSL: queryDSLValue },
@@ -257,6 +252,9 @@ const PropertyView = (props: { comp: InstanceType<typeof LibraryQuery> }) => {
   const info = queryLibraryRecord[queryId]?.[recordId];
 
   useEffect(() => {
+    if (info === undefined) {
+      return;
+    }
     dispatch(
       customAction<QueryLibraryUpdateAction>({ type: "queryLibraryUpdate", dsl: info }, true)
     );
@@ -326,17 +324,14 @@ const PropertyView = (props: { comp: InstanceType<typeof LibraryQuery> }) => {
               value: meta.libraryQueryMetaView.id,
             }))}
             value={queryId ?? queryLibraryMeta[0]?.libraryQueryMetaView.id}
-            onChange={(value) => {
-              const queryDSL = queryLibraryMeta[value]?.libraryQueryMetaView || null;
-              const { datasourceType } = queryDSL as any;
-
-              props.comp.dispatch(
+            onChange={(value) =>
+              dispatch(
                 multiChangeAction({
                   libraryQueryId: changeValueAction(value, false),
-                  libraryQueryType: changeValueAction(datasourceType, false),
+                  libraryQueryDSL: changeValueAction(null, false),
                 })
               )
-            }}
+            }
           />
         </div>
         <QueryTutorialButton
@@ -357,7 +352,14 @@ const PropertyView = (props: { comp: InstanceType<typeof LibraryQuery> }) => {
           })) ?? []),
         ]}
         value={recordId}
-        onChange={(value) => dispatch(props.comp.changeChildAction("libraryQueryRecordId", value))}
+        onChange={(value) =>
+          dispatch(
+            multiChangeAction({
+              libraryQueryRecordId: changeValueAction(value, false),
+              libraryQueryDSL: changeValueAction(null, false),
+            })
+          )
+        }
       />
 
       {getInputsView()}


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue for the JS prepared query, which used to return the plugin failed and was being sent to the backend 
more details on the:

1. https://discord.com/channels/1096896040159957084/1096896040650678314/1542858159427813487
2. #2177 

## Types of changes
What types of changes does your code introduce to Lowcoder?  
_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.  
_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
